### PR TITLE
Fix python pillow

### DIFF
--- a/.github/workflows/build_additional.yaml
+++ b/.github/workflows/build_additional.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel fann gcc-fortran cargo portaudio ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf llvm alsa-lib libjpeg-turbo openjpeg2 libtiff 
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel fann gcc-fortran cargo portaudio ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf llvm alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update

--- a/.github/workflows/build_additional.yaml
+++ b/.github/workflows/build_additional.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel fann gcc-fortran cargo portaudio ninja python-google-api-core python-setuptools python-wheel pkgconf llvm alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel fann gcc-fortran cargo portaudio ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf llvm alsa-lib libjpeg-turbo openjpeg2 libtiff 
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update

--- a/.github/workflows/build_audio.yaml
+++ b/.github/workflows/build_audio.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel pkgconf portaudio alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf portaudio alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update

--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel pkgconf alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update

--- a/.github/workflows/build_listener.yaml
+++ b/.github/workflows/build_listener.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel pkgconf alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update

--- a/.github/workflows/build_phal.yaml
+++ b/.github/workflows/build_phal.yaml
@@ -10,22 +10,23 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel cargo gcc-fortran fann ninja python-google-api-core python-setuptools python-wheel pkgconf alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel cargo gcc-fortran fann ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update
       - name: gen PKGBUILDS
+          # already built with ovos-phal
+          # sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-system
+          # sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-color-scheme-manager
+          # sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-network-manager
+          # sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-phal-plugin-ipgeo
+          # sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-oauth
         run: |
           sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-phal
           sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-phal-plugin-connectivity-events
           sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-wallpaper-manager
           sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-brightness-control-rpi
-          sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-network-manager
-          sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-phal-plugin-ipgeo
-          sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-oauth
           sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-alsa
-          sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-system
-          sudo -u nobody pypi2pkgbuild.py --base-path /tmp/build --force --no-install --pre ovos-PHAL-plugin-color-scheme-manager
       - uses: actions/checkout@v3
         with:
           ref: dev

--- a/.github/workflows/build_plugins.yaml
+++ b/.github/workflows/build_plugins.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip python-setuptools git swig cython gcc-fortran base-devel fann cargo ninja python-google-api-core python-setuptools python-wheel pkgconf llvm alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip python-setuptools git swig cython gcc-fortran base-devel fann cargo ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf llvm alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update

--- a/.github/workflows/build_skills.yaml
+++ b/.github/workflows/build_skills.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Install build Dependencies
         run: |
-          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel pkgconf alsa-lib
+          sudo pacman --noconfirm --needed -Sy pkgfile namcap python-pip git swig cython base-devel gcc-fortran fann cargo ninja python-google-api-core python-setuptools python-wheel python-pillow pkgconf alsa-lib
           yes | LC_ALL=en_US.UTF-8 sudo pacman -S openblas
           pip install git+https://github.com/anntzer/pypi2pkgbuild
           pkgfile --update


### PR DESCRIPTION
Somehow pypi2pkgbuild doesn't recognize `python-pillow` already available on official repos